### PR TITLE
Compatibility with Typst 0.13

### DIFF
--- a/common/tudapub_outline.typ
+++ b/common/tudapub_outline.typ
@@ -122,11 +122,8 @@
     )[Contents]
 
 
-    locate(loc => {
-      let headings = query(
-        selector(heading.where(outlined: true)).after(loc),
-        loc,
-      )
+    context {
+      let headings = query(selector(heading.where(outlined: true)).after(here()))
 
 
       
@@ -205,7 +202,7 @@
           \
         ]
       }
-    })
+    }
 
   }
 

--- a/common/tudapub_title_page.typ
+++ b/common/tudapub_title_page.typ
@@ -139,7 +139,7 @@
       )[
         
         #v(logo_tud_height/2)
-        #style(styles => {
+        #context {
           //let tud_logo = image(logo_tuda_path, height: logo_tud_height)
           let tud_logo = [
                 #set image(height: logo_tud_height)
@@ -149,7 +149,7 @@
                   logo_tuda
                 } 
           ]
-          let tud_logo_width = measure(tud_logo, styles).width
+          let tud_logo_width = measure(tud_logo).width
           let tud_logo_offset_right = -6.3mm
           tud_logo_width += tud_logo_offset_right
 
@@ -203,7 +203,7 @@
             }
             )
           ]
-        })
+        }
         
       ]
     )

--- a/common/util.typ
+++ b/common/util.typ
@@ -1,7 +1,7 @@
-#let natural-image(..args) = style(styles => {
-  let (width, height) = measure(image(..args), styles)
+#let natural-image(..args) = context {
+  let (width, height) = measure(image(..args))
   image(..args, width: width, height: height)
-})
+}
 
 
 

--- a/templates/tudapub/template/tudapub.typ
+++ b/templates/tudapub/template/tudapub.typ
@@ -200,7 +200,8 @@
     //leading: 4.7pt//0.42em//4.7pt   // line spacing
     leading: 4.8pt//0.42em//4.7pt   // line spacing
   )
-  show par: set block(below: 1.1em) // was 1.2em
+  // show par: set block(below: 1.1em) // was 1.2em
+  set par(spacing: 1.1em)
 
   set text(
     font: "XCharter",

--- a/templates/tudapub/template/tudapub.typ
+++ b/templates/tudapub/template/tudapub.typ
@@ -175,7 +175,7 @@
 
   // content.
   body
-) = style(styles => {
+) = context {
   // checks
   //assert(tuda_colors.keys().contains(accentcolor), "accentcolor unknown")
   //assert.eq(paper, "a4", "currently just a4 is supported as paper size")
@@ -254,17 +254,17 @@
         #let counter_disp = counter(page).display()
         //#hide(counter_disp)
         //#counter_disp
-        #locate(loc => {
-          let after_table_of_contents = query(selector(<__after_table_of_contents>).before(loc), loc).len() >= 1
+        #context {
+          let after_table_of_contents = query(selector(<__after_table_of_contents>).before(here())).len() >= 1
           if after_table_of_contents {counter_disp}
           else {hide(counter_disp)}
-        })
+        }
       ]
     ]
   )
 
-  let header_height = measure(header, styles).height
-  let footer_height = measure(footer, styles).height
+  let header_height = measure(header).height
+  let footer_height = measure(footer).height
 
   // inner page margins (from header to text and text to footer)
   let inner_page_margin_top = 22pt //0pt//20pt //3mm
@@ -288,7 +288,7 @@
   set heading(numbering: "1.1")
 
   // default heading (handle cases with level >= 3 < 5)
-  show heading: it => locate(loc => {
+  show heading: it => context {
     if it.level > 5 {
       panic("Just heading with a level < 4 are supported.")
     }
@@ -301,7 +301,7 @@
     // change heading margin depending on its the first on the page
     let (heading_margin_before, is_first_on_page) = get-spacing-zero-if-first-on-page(
       heading_3_margin_before, 
-      loc, 
+      here(), 
       content_page_margin_full_top,
       enable: reduce_heading_space_when_first_on_page
     )
@@ -325,7 +325,7 @@
         v(10pt)
       )
     ]
-  })
+  }
 
 
   // heading level 5
@@ -395,11 +395,11 @@
   // heading level 2 
   show heading.where(
     level: 2
-  ): it => locate(loc => {
+  ): it => context {
     // change heading margin depending if its the first on the page
     let (heading_margin_before, is_first_on_page) = get-spacing-zero-if-first-on-page(
       heading_2_margin_before, 
-      loc, 
+      here(), 
       content_page_margin_full_top,
       enable: reduce_heading_space_when_first_on_page
     )
@@ -434,7 +434,7 @@
         v(10pt)
       )
     ]
-  })
+  }
 
 
 
@@ -660,4 +660,4 @@
     #set bibliography(style: "ieee")
     #bib
   ]
-})
+}


### PR DESCRIPTION
Hi,

I have noticed that the template cannot be compiled with the newest Typst version (0.13). This is an attempt to make it compatible again. Please double-check that I have not broken anything and everything looks as it is supposed to.

Based on the migration guides ([0.12](https://typst.app/blog/2024/typst-0.12/#migrating-your-documents), [0.13](https://typst.app/blog/2025/typst-0.13#migrating)), I made the following changes:

- `style` statements were replaced by `context` statements
- `locate` statements were replaced by `context` statements, using `here()` instead of `loc` when necessary
- Paragraph spacing is set using the `spacing` parameter of `par` (instead of the parameter of `block`)