### PR TITLE
autmatic term mechanism for exercises

### DIFF
--- a/templates/tudaexercise/template/locales.typ
+++ b/templates/tudaexercise/template/locales.typ
@@ -7,6 +7,8 @@
   tutor: "Tutor",
   lecturer: "Dozent",
   term: "Semester",
+  summer_term: "Sommersemester",
+  winter_term: "Wintersemester",
   date: "Abgabe"
 )
 
@@ -19,5 +21,7 @@
   tutor: "Tutor",
   lecturer: "Lecturer",
   term: "Term",
+  summer_term: "Summer semester",
+  winter_term: "Winter semester",
   date: "Due"
 )

--- a/templates/tudaexercise/template/title-sub.typ
+++ b/templates/tudaexercise/template/title-sub.typ
@@ -19,7 +19,22 @@
 /// -> function
 #let exercise(additional: none) = (info, dict) => {
   if "term" in info {
-    info.term
+    if(info.term == auto) {
+      // if month between 4 and 9 then it's summer term, else it's winter term
+      let month = datetime.today().month
+      let year = datetime.today().year
+      info.term = if month >= 4 and month <= 9 {
+        dict.summer_term + " " + year
+      } else {
+        dict.winter_term
+        if (month < 4) {
+          year--
+        }
+        + " " + year + "/" + year + 1
+      }
+    } else {
+      info.term
+    }
     linebreak()
   }
   if "date" in info {

--- a/templates/tudaexercise/template/title-sub.typ
+++ b/templates/tudaexercise/template/title-sub.typ
@@ -21,20 +21,19 @@
   if "term" in info {
     if(info.term == auto) {
       // if month between 4 and 9 then it's summer term, else it's winter term
-      let month = datetime.today().month
-      let year = datetime.today().year
+      let month = datetime.today().month()
+      let year = datetime.today().year()
       info.term = if month >= 4 and month <= 9 {
-        dict.summer_term + " " + year
+        dict.summer_term + " " + str(year)
       } else {
         dict.winter_term
         if (month < 4) {
-          year--
+          year = year - 1
         }
-        + " " + year + "/" + year + 1
+        " " + str(year) + "/" + str(year + 1)
       }
-    } else {
-      info.term
     }
+    info.term
     linebreak()
   }
   if "date" in info {

--- a/templates_examples/tudaexercise/main.typ
+++ b/templates_examples/tudaexercise/main.typ
@@ -6,7 +6,7 @@
     title: "Usage of TUDaExercise",
     subtitle: "A small guide.",
     author: (("Andreas", "129219"), "Dennis"),
-    term: "Summer semester 2042",
+    term: auto,
     date: datetime.today(),
     sheet: 5,
     group: 1,


### PR DESCRIPTION
This PR adds the functionality to set the term to `auto` instead of a text, and it will resolve the current term automatically:
<img width="373" height="114" alt="image" src="https://github.com/user-attachments/assets/42390544-58b3-48d3-bb8d-265357541fef" />
